### PR TITLE
Prepare Enterprise Beans Deployment Descriptor for 4.0

### DIFF
--- a/jakartaee9/src/application-client_9.xsds
+++ b/jakartaee9/src/application-client_9.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"
@@ -42,15 +42,15 @@
 	deployment descriptors must indicate the application
 	client schema by using the Jakarta EE namespace:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee
+	https://jakarta.ee/xml/ns/jakartaee
 
 	and indicate the version of the schema by
 	using the version element as shown below:
 
-	    <application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    <application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	      xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-		http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+		https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd"
 	      version="9">
 	      ...
 	    </application-client>
@@ -59,7 +59,7 @@
 	the schema using the xsi:schemaLocation attribute for Jakarta EE
 	namespace with the following location:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd
+	https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd
 
 	]]>
     </xsd:documentation>

--- a/jakartaee9/src/application_9.xsds
+++ b/jakartaee9/src/application_9.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"
@@ -41,15 +41,15 @@
 	All application deployment descriptors must indicate
 	the application schema by using the Jakarta EE namespace:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee
+	https://jakarta.ee/xml/ns/jakartaee
 
 	and indicate the version of the schema by
 	using the version element as shown below:
 
-	    <application xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	      xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-		http://xmlns.eclipse.org/xml/ns/jakartaee/application_9.xsd"
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+		https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
 	      version="9">
 	      ...
 	    </application>
@@ -58,7 +58,7 @@
 	the schema using the xsi:schemaLocation attribute for Jakarta EE
 	namespace with the following location:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee/application_9.xsd
+	https://jakarta.ee/xml/ns/jakartaee/application_9.xsd
 
 	]]>
     </xsd:documentation>

--- a/jakartaee9/src/common.inc
+++ b/jakartaee9/src/common.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-      The following conventions apply to all Java EE
+      The following conventions apply to all Jakarta EE
       deployment descriptor elements unless indicated otherwise.
 
       - In elements that specify a pathname to a file within the

--- a/jakartaee9/src/connector_1_7.xsds
+++ b/jakartaee9/src/connector_1_7.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"
@@ -41,15 +41,15 @@
 	deployment descriptors must indicate the connector resource
 	adapter schema by using the Jakarta EE namespace:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee
+	https://jakarta.ee/xml/ns/jakartaee
 
 	and by indicating the version of the schema by
 	using the version element as shown below:
 
-	    <connector xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    <connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	      xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-		 http://xmlns.eclipse.org/xml/ns/jakartaee/connector_1_7.xsd"
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+		 https://jakarta.ee/xml/ns/jakartaee/connector_1_7.xsd"
 	      version="1.7">
 	      ...
 	    </connector>
@@ -58,7 +58,7 @@
 	the schema using the xsi:schemaLocation attribute for Jakarta EE
 	namespace with the following location:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee/connector_1_7.xsd
+	https://jakarta.ee/xml/ns/jakartaee/connector_1_7.xsd
 
 	]]>
     </xsd:documentation>

--- a/jakartaee9/src/ejb-jar_4_0.xsds
+++ b/jakartaee9/src/ejb-jar_4_0.xsds
@@ -257,7 +257,7 @@
 	    the name for an activation configuration property of
 	    a message-driven bean.
 
-	    For JMS message-driven beans, the following property
+	    For Jakarta Messaging message-driven beans, the following property
 	    names are recognized: acknowledgeMode,
 	    messageSelector, destinationType, subscriptionDurability,
             destinationLookup, connectionFactoryLookup, subscriptionName,
@@ -2933,7 +2933,7 @@
 	    service endpoint interface. The service-endpoint
 	    element may only be specified for a stateless
 	    session bean. The specified interface must be a
-	    valid JAX-RPC service endpoint interface.
+	    valid Jakarta XML RPC service endpoint interface.
 
 	  </xsd:documentation>
 	</xsd:annotation>

--- a/jakartaee9/src/ejb-jar_4_0.xsds
+++ b/jakartaee9/src/ejb-jar_4_0.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,12 +18,12 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"
-	    version="3.2">
+	    version="4.0">
 
   <xsd:annotation>
     <xsd:documentation>
@@ -35,21 +35,21 @@
     <xsd:documentation>
       <![CDATA[
 
-	This is the XML Schema for the EJB 3.2 deployment descriptor.
+	This is the XML Schema for the Enterprise Beans 4.0 deployment descriptor.
 
-        All EJB deployment descriptors must indicate
+        All Enterprise Beans deployment descriptors must indicate
 	the schema by using the Jakarta EE namespace:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee
+	https://jakarta.ee/xml/ns/jakartaee
 
 	and by indicating the version of the schema by
 	using the version element as shown below:
 
-	    <ejb-jar xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    <ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	      xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-		  http://xmlns.eclipse.org/xml/ns/jakartaee/ejb-jar_3_2.xsd"
-	      version="3.2">
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+		  https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd"
+	      version="4.0">
 	      ...
 	    </ejb-jar>
 
@@ -57,7 +57,7 @@
 	the schema using the xsi:schemaLocation attribute for the
 	Jakarta EE namespace with the following location:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee/ejb-jar_3_2.xsd
+	https://jakarta.ee/xml/ns/jakartaee/ejb-jar_3_2.xsd
 
 	]]>
     </xsd:documentation>
@@ -435,7 +435,7 @@
 	    cmp-version 1.x must denote a public field of the
 	    enterprise bean class or one of its superclasses.
 
-	    Support for entity beans is optional as of EJB 3.2.
+	    Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  </xsd:documentation>
 	</xsd:annotation>
@@ -459,7 +459,7 @@
 	    1.x
 	    2.x
 
-	Support for entity beans is optional as of EJB 3.2.
+	Support for entity beans is optional as of Enterprise Beans 3.2.
 
       </xsd:documentation>
     </xsd:annotation>
@@ -486,7 +486,7 @@
 	used only for collection-valued cmr-fields. It specifies the
 	type of the collection that is used.
 
-	Support for entity beans is optional as of EJB 3.2.
+	Support for entity beans is optional as of Enterprise Beans 3.2.
 
       </xsd:documentation>
     </xsd:annotation>
@@ -509,7 +509,7 @@
 	    specified by cmr-field-name in which the first
 	    letter is uppercased, prefixed by "get" or "set".
 
-	    Support for entity beans is optional as of EJB 3.2.
+	    Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  </xsd:documentation>
 	</xsd:annotation>
@@ -720,7 +720,7 @@
     <xsd:annotation>
       <xsd:documentation>
 
-	The ejb-jarType defines the root element of the EJB
+	The ejb-jarType defines the root element of the Enterprise Beans
 	deployment descriptor. It contains
 
 	    - an optional description of the ejb-jar file
@@ -809,16 +809,16 @@
     </xsd:sequence>
     <xsd:attribute name="version"
 		   type="jakartaee:dewey-versionType"
-		   fixed="3.2"
+		   fixed="4.0"
 		   use="required">
       <xsd:annotation>
 	<xsd:documentation>
 
 	  The version specifies the version of the
-	  EJB specification that the instance document must 
+	  Enterprise Beans specification that the instance document must 
 	  comply with. This information enables deployment tools
-	  to validate a particular EJB Deployment
-	  Descriptor with respect to a specific version of the EJB
+	  to validate a particular Enterprise Beans Deployment
+	  Descriptor with respect to a specific version of the Enterprise Beans
 	  schema. 
 
 	</xsd:documentation>
@@ -902,7 +902,7 @@
 	relationship, if specified, is unique within the ejb-jar
 	file.
 
-	Support for entity beans is optional as of EJB 3.2.
+	Support for entity beans is optional as of Enterprise Beans 3.2.
 
       </xsd:documentation>
     </xsd:annotation>
@@ -976,7 +976,7 @@
 	       </ejb-relationship-role>
 	  </ejb-relation>
 
-	  Support for entity beans is optional as of EJB 3.2.
+	  Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  ]]>
       </xsd:documentation>
@@ -1018,7 +1018,7 @@
 	    which the other ejb-relationship-role
 	    element specifies a multiplicity of One.
 
-	    Support for entity beans is optional as of EJB 3.2.
+	    Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  </xsd:documentation>
 	</xsd:annotation>
@@ -1053,7 +1053,7 @@
 	    <xsd:documentation>
 
 	      The ejb-ref-name element contains the name of
-	      an EJB reference. The EJB reference is an entry in
+	      an enterprise bean reference. The enterprise bean reference is an entry in
 	      the component's environment and is relative to the
 	      java:comp/env context.  The name must be unique within
 	      the component.
@@ -1070,8 +1070,8 @@
 	  <xsd:annotation>
 	    <xsd:documentation>
 
-	      The ejb-ref-name element contains the name of an EJB
-	      reference. The EJB reference is an entry in the
+	      The ejb-ref-name element contains the name of an enterprise bean
+	      reference. The enterprise bean reference is an entry in the
 	      component's environment and is relative to the
 	      java:comp/env context. The name must be unique
 	      within the component.
@@ -1157,7 +1157,7 @@
 	    <xsd:documentation>
 
 	      The ejb-ref-name element contains the name of
-	      an EJB reference. The EJB reference is an entry in
+	      an enterprise bean reference. The enterprise bean reference is an entry in
 	      the component's environment and is relative to the
 	      java:comp/env context.  The name must be unique within
 	      the component.
@@ -1174,8 +1174,8 @@
 	  <xsd:annotation>
 	    <xsd:documentation>
 
-	      The ejb-ref-name element contains the name of an EJB
-	      reference. The EJB reference is an entry in the
+	      The ejb-ref-name element contains the name of an enterprise bean
+	      reference. The enterprise bean reference is an entry in the
 	      component's environment and is relative to the
 	      java:comp/env context. The name must be unique
 	      within the component.
@@ -1260,7 +1260,7 @@
 	    <xsd:documentation>
 
 	      The ejb-ref-name element contains the name of
-	      an EJB reference. The EJB reference is an entry in
+	      an enterprise bean reference. The enterprise bean reference is an entry in
 	      the component's environment and is relative to the
 	      java:comp/env context.  The name must be unique within
 	      the component.
@@ -1277,8 +1277,8 @@
 	  <xsd:annotation>
 	    <xsd:documentation>
 
-	      The ejb-ref-name element contains the name of an EJB
-	      reference. The EJB reference is an entry in the
+	      The ejb-ref-name element contains the name of an enterprise bean
+	      reference. The enterprise bean reference is an entry in the
 	      component's environment and is relative to the
 	      java:comp/env context. The name must be unique
 	      within the component.
@@ -1366,7 +1366,7 @@
     <xsd:annotation>
       <xsd:documentation>
 
-        Support for entity beans is optional as of EJB 3.2.
+        Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	The entity-beanType declares an entity bean. The declaration
 	consists of:
@@ -1400,10 +1400,10 @@
 	      field
 	    - an optional declaration of the bean's environment 
 	      entries
-	    - an optional declaration of the bean's EJB 
+	    - an optional declaration of the bean's  
 	      references
 	    - an optional declaration of the bean's local 
-	      EJB references
+	      references
 	    - an optional declaration of the bean's web 
 	      service references
 	    - an optional declaration of the security role 
@@ -1497,7 +1497,7 @@
 	    deferred to deployment time, the prim-key-class 
 	    element should specify java.lang.Object.
 
-	    Support for entity beans is optional as of EJB 3.2.
+	    Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  </xsd:documentation>
 	</xsd:annotation>
@@ -1527,13 +1527,13 @@
 
 	    The abstract-schema-name element specifies the name
 	    of the abstract schema type of an entity bean with 
-	    cmp-version 2.x. It is used in EJB QL queries. 
+	    cmp-version 2.x. It is used in Enterprise Beans QL queries. 
 
 	    For example, the abstract-schema-name for an entity 
 	    bean whose local interface is 
 	    com.acme.commerce.Order might be Order. 
 
-	    Support for entity beans is optional as of EJB 3.2.
+	    Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  </xsd:documentation>
 	</xsd:annotation>
@@ -1563,7 +1563,7 @@
 	    their names must correspond to the field names of
 	    the entity bean class that comprise the key.
 
-	    Support for entity beans is optional as of EJB 3.2.
+	    Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  </xsd:documentation>
 	</xsd:annotation>
@@ -1973,9 +1973,8 @@
               superclass around-timeout methods.
 	    - an optional declaration of the bean's environment
 	      entries
-	    - an optional declaration of the bean's EJB references
-	    - an optional declaration of the bean's local EJB
-	      references
+	    - an optional declaration of the bean's references
+	    - an optional declaration of the bean's local references
 	    - an optional declaration of the bean's web service
 	      references
 	    - an optional declaration of the security role 
@@ -2525,7 +2524,7 @@
 	    One
 	    Many
 
-	Support for entity beans is optional as of EJB 3.2.
+	Support for entity beans is optional as of Enterprise Beans 3.2.
 
       </xsd:documentation>
     </xsd:annotation>
@@ -2551,7 +2550,7 @@
 	    Bean
 	    Container
 
-	Support for entity beans is optional as of EJB 3.2.
+	Support for entity beans is optional as of Enterprise Beans 3.2.
 
       </xsd:documentation>
     </xsd:annotation>
@@ -2577,11 +2576,11 @@
 		- an optional specification of the result type 
 		  mapping, if the query is for a select method 
 		  and entity objects are returned.
-		- the EJB QL query string that defines the query.
+		- the Enterprise Beans QL query string that defines the query.
 
-	Queries that are expressible in EJB QL must use the ejb-ql
+	Queries that are expressible in Enterprise Beans QL must use the ejb-ql
 	element to specify the query. If a query is not expressible
-	in EJB QL, the description element should be used to
+	in Enterprise Beans QL, the description element should be used to
 	describe the semantics of the query and the ejb-ql element
 	should be empty.
 
@@ -2639,7 +2638,7 @@
 	      </ejb-ql>
 	  </query>
 
-	  Support for entity beans is optional as of EJB 3.2.
+	  Support for entity beans is optional as of Enterprise Beans 3.2.
 
 	  ]]>
       </xsd:documentation>
@@ -2667,7 +2666,7 @@
 	relationship-role-source elements to uniquely identify an
 	entity bean.
 
-	Support for entity beans is optional as of EJB 3.2.
+	Support for entity beans is optional as of Enterprise Beans 3.2.
 
       </xsd:documentation>
     </xsd:annotation>
@@ -2695,7 +2694,7 @@
 	description; and a list of ejb-relation elements, which
 	specify the container managed relationships.
 
-	Support for entity beans is optional as of EJB 3.2.
+	Support for entity beans is optional as of Enterprise Beans 3.2.
 
       </xsd:documentation>
     </xsd:annotation>
@@ -2854,9 +2853,9 @@
               superclass around-timeout methods.
 	    - an optional declaration of the bean's 
 	      environment entries
-	    - an optional declaration of the bean's EJB references
+	    - an optional declaration of the bean's references
 	    - an optional declaration of the bean's local 
-	      EJB references
+	      references
 	    - an optional declaration of the bean's web 
 	      service references
 	    - an optional declaration of the security role 
@@ -3008,7 +3007,7 @@
 	  <xsd:documentation>
 
 	    The init-method element specifies the mappings for
-	    EJB 2.x style create methods for an EJB 3.x bean.
+	    Enterprise Beans 2.x style create methods for an Enterprise Beans 3.x bean.
 	    This element can only be specified for stateful 
             session beans. 
 
@@ -3023,7 +3022,7 @@
 	  <xsd:documentation>
 
 	    The remove-method element specifies the mappings for
-	    EJB 2.x style remove methods for an EJB 3.x bean.
+	    Enterprise Beans 2.x style remove methods for an Enterprise Beans 3.x bean.
 	    This element can only be specified for stateful 
             session beans. 
 

--- a/jakartaee9/src/ejb-jar_4_0.xsds
+++ b/jakartaee9/src/ejb-jar_4_0.xsds
@@ -1400,9 +1400,9 @@
 	      field
 	    - an optional declaration of the bean's environment 
 	      entries
-	    - an optional declaration of the bean's  
+	    - an optional declaration of the bean's enterprise bean 
 	      references
-	    - an optional declaration of the bean's local 
+	    - an optional declaration of the bean's local enterprise bean 
 	      references
 	    - an optional declaration of the bean's web 
 	      service references
@@ -1973,8 +1973,9 @@
               superclass around-timeout methods.
 	    - an optional declaration of the bean's environment
 	      entries
-	    - an optional declaration of the bean's references
-	    - an optional declaration of the bean's local references
+	    - an optional declaration of the bean's enterprise bean references
+	    - an optional declaration of the bean's local enterprise bean 
+		  references
 	    - an optional declaration of the bean's web service
 	      references
 	    - an optional declaration of the security role 
@@ -2853,8 +2854,8 @@
               superclass around-timeout methods.
 	    - an optional declaration of the bean's 
 	      environment entries
-	    - an optional declaration of the bean's references
-	    - an optional declaration of the bean's local 
+	    - an optional declaration of the bean's enterprise bean references
+	    - an optional declaration of the bean's local enterprise bean
 	      references
 	    - an optional declaration of the bean's web 
 	      service references

--- a/jakartaee9/src/glossary.inc
+++ b/jakartaee9/src/glossary.inc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,12 +15,12 @@
  */
 
 The following definitions that appear in the common
-shareable schema(s) of Java EE deployment descriptors should be
+shareable schema(s) of Jakarta EE deployment descriptors should be
 interpreted with respect to the context they are included:
 
 
 Deployment Component may indicate one of the following:
-    java ee application;
+    Jakarta EE application;
     application client;
     web application;
     enterprise bean;

--- a/jakartaee9/src/jakartaee_9.xsds
+++ b/jakartaee9/src/jakartaee_9.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema
-     targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-     xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+     targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+     xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema"
      elementFormDefault="qualified"
      attributeFormDefault="unqualified"

--- a/jakartaee9/src/jakartaee_web_services_1_4.xsds
+++ b/jakartaee9/src/jakartaee_web_services_1_4.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"
@@ -53,15 +53,15 @@
 	All webservices deployment descriptors must indicate the
 	webservices schema by using the Jakarta EE namespace:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee
+	https://jakarta.ee/xml/ns/jakartaee
 
 	and by indicating the version of the schema by using the version
 	element as shown below:
 
-	    <webservices xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    <webservices xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	      xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-		http://xmlns.eclipse.org/xml/ns/jakartaee/jakartaee_web_services_1_4.xsd"
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+		https://jakarta.ee/xml/ns/jakartaee/jakartaee_web_services_1_4.xsd"
 	      version="1.4">
 	      ...
 	    </webservices>
@@ -70,7 +70,7 @@
 	schema using the xsi:schemaLocation attribute for the Jakarta EE
 	namespace with the following location:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee/jakartaee_web_services_1_4.xsd
+	https://jakarta.ee/xml/ns/jakartaee/jakartaee_web_services_1_4.xsd
 
 	]]>
     </xsd:documentation>

--- a/jakartaee9/src/jakartaee_web_services_client_1_4.xsds
+++ b/jakartaee9/src/jakartaee_web_services_client_1_4.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"

--- a/jakartaee9/src/jsp_3_0.xsds
+++ b/jakartaee9/src/jsp_3_0.xsds
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"

--- a/jakartaee9/src/permissions_7.xsds
+++ b/jakartaee9/src/permissions_7.xsds
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-	    targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-	    xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+	    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
 	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
 	    elementFormDefault="qualified"
 	    attributeFormDefault="unqualified"
@@ -42,15 +42,15 @@
 	the declared permissions schema by using the Jakarta EE namespace:
 
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee
+	https://jakarta.ee/xml/ns/jakartaee
 
 	and indicate the version of the schema by
 	using the version element as shown below:
 
-	    <permissions xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+	    <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	      xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-		http://xmlns.eclipse.org/xml/ns/jakartaee/permissions_7.xsd"
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+		https://jakarta.ee/xml/ns/jakartaee/permissions_7.xsd"
 	      version="7">
 	      ...
 	    </permisssions>
@@ -59,7 +59,7 @@
 	the schema using the xsi:schemaLocation attribute for Jakarta EE
 	namespace with the following location:
 
-	http://xmlns.eclipse.org/xml/ns/jakartaee/permissions_7.xsd
+	https://jakarta.ee/xml/ns/jakartaee/permissions_7.xsd
 
 	]]>
     </xsd:documentation>

--- a/jakartaee9/src/web-app_4_0.xsds
+++ b/jakartaee9/src/web-app_4_0.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-            xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
@@ -41,12 +41,12 @@
         must indicate the web application schema by using the Jakarta EE
         namespace:
 
-        http://xmlns.eclipse.org/xml/ns/jakartaee
+        https://jakarta.ee/xml/ns/jakartaee
 
         and by indicating the version of the schema by
         using the version element as shown below:
 
-            <web-app xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+            <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="..."
               version="4.0">
@@ -57,7 +57,7 @@
         the schema using the xsi:schemaLocation attribute for Jakarta EE
         namespace with the following location:
 
-        http://xmlns.eclipse.org/xml/ns/jakartaee/web-app_4_0.xsd
+        https://jakarta.ee/xml/ns/jakartaee/web-app_4_0.xsd
 
         ]]>
     </xsd:documentation>

--- a/jakartaee9/src/web-common_4_0.xsds
+++ b/jakartaee9/src/web-common_4_0.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-            xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
@@ -41,12 +41,12 @@
         must indicate the web common schema by using the Jakarta EE
         namespace:
 
-        http://xmlns.eclipse.org/xml/ns/jakartaee
+        https://jakarta.ee/xml/ns/jakartaee
 
         and by indicating the version of the schema by
         using the version element as shown below:
 
-            <web-app xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+            <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="..."
               version="4.0">
@@ -57,7 +57,7 @@
         the schema using the xsi:schemaLocation attribute for Jakarta EE
         namespace with the following location:
 
-        http://xmlns.eclipse.org/xml/ns/jakartaee/web-common_4_0.xsd
+        https://jakarta.ee/xml/ns/jakartaee/web-common_4_0.xsd
 
         ]]>
     </xsd:documentation>

--- a/jakartaee9/src/web-facelettaglibrary_2_3.xsds
+++ b/jakartaee9/src/web-facelettaglibrary_2_3.xsds
@@ -17,8 +17,8 @@
 
 -->
 
-<xsd:schema targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-            xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:xml="http://www.w3.org/XML/1998/namespace"
             elementFormDefault="qualified"
@@ -42,9 +42,9 @@
       <p>JSF 2.3 Facelet Tag Libraries that wish to conform to this
       schema must declare it in the following manner.</p>
       
-      &lt;facelet-taglib xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+      &lt;facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee http://xmlns.eclipse.org/xml/ns/jakartaee/web-facelettaglibary_2_3.xsd"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibary_2_3.xsd"
       version="2.3"&gt;
       
       ...
@@ -55,7 +55,7 @@
       version of the schema using xsi:schemaLocation attribute
       for jakartaee namespace with the following location:</p>
       
-      <p>http://xmlns.eclipse.org/xml/ns/jakartaee/web-facelettaglibary_2_3.xsd</p>
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibary_2_3.xsd</p>
       
       ]]>
     </xsd:documentation>

--- a/jakartaee9/src/web-facesconfig_2_3.xsds
+++ b/jakartaee9/src/web-facesconfig_2_3.xsds
@@ -17,10 +17,10 @@
 
 -->
 
-<xsd:schema xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<xsd:schema xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
             attributeFormDefault="unqualified" 
             elementFormDefault="qualified" 
-            targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee" 
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee" 
             version="2.3" 
             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <xsd:include schemaLocation="jakartaee_9.xsd" />
@@ -42,12 +42,12 @@
       the JavaServer Faces schema by indicating the JavaServer
       Faces namespace:</p>
       
-      <p>http://xmlns.eclipse.org/xml/ns/jakartaee</p>
+      <p>https://jakarta.ee/xml/ns/jakartaee</p>
       
       <p>and by indicating the version of the schema by
       using the version element as shown below:</p>
       
-      <pre>&lt;faces-config xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+      <pre>&lt;faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="..."
       version="2.2"&gt;
@@ -58,7 +58,7 @@
       version of the schema using xsi:schemaLocation attribute
       for jakartaee namespace with the following location:</p>
       
-      <p>http://xmlns.eclipse.org/xml/ns/jakartaee/web-facesconfig_2_3.xsd</p>
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_2_3.xsd</p>
       
       ]]>
     </xsd:documentation>

--- a/jakartaee9/src/web-fragment_4_0.xsds
+++ b/jakartaee9/src/web-fragment_4_0.xsds
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,8 +18,8 @@
 -->
 
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
-            xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
@@ -41,12 +41,12 @@
         must indicate the web application schema by using the Jakarta EE
         namespace:
 
-        http://xmlns.eclipse.org/xml/ns/jakartaee
+        https://jakarta.ee/xml/ns/jakartaee
 
         and by indicating the version of the schema by
         using the version element as shown below:
 
-            <web-fragment xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+            <web-fragment xmlns="https://jakarta.ee/xml/ns/jakartaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="..."
               version="4.0">
@@ -57,7 +57,7 @@
         the schema using the xsi:schemaLocation attribute for Jakarta EE
         namespace with the following location:
 
-        http://xmlns.eclipse.org/xml/ns/jakartaee/web-fragment_4_0.xsd
+        https://jakarta.ee/xml/ns/jakartaee/web-fragment_4_0.xsd
 
         ]]>
     </xsd:documentation>

--- a/jakartaee9/src/web-partialresponse_2_3.xsds
+++ b/jakartaee9/src/web-partialresponse_2_3.xsds
@@ -17,10 +17,10 @@
 
 -->
 
-<xsd:schema xmlns:jakartaee="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<xsd:schema xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
             attributeFormDefault="unqualified"
             elementFormDefault="qualified"
-            targetNamespace="http://xmlns.eclipse.org/xml/ns/jakartaee"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
             version="2.3"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <xsd:include schemaLocation="jakartaee_9.xsd"/>

--- a/jakartaee9/test/app-client-complete.xml
+++ b/jakartaee9/test/app-client-complete.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     metadata-complete="true"
     version="9">
   <module-name>MyModule</module-name>

--- a/jakartaee9/test/app-client-data-source.xml
+++ b/jakartaee9/test/app-client-data-source.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client-handler.xml
+++ b/jakartaee9/test/app-client-handler.xml
@@ -17,13 +17,13 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:c1="http://HandlerInfo.org/Client1"
     xmlns:c2="http://HandlerInfo.org/Client2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     version="9">
   <display-name>HandlerInfoTestClnt_client</display-name>
   <service-ref>

--- a/jakartaee9/test/app-client-injection.xml
+++ b/jakartaee9/test/app-client-injection.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client-mapped-name.xml
+++ b/jakartaee9/test/app-client-mapped-name.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client-module.xml
+++ b/jakartaee9/test/app-client-module.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     version="9">
   <module-name>MyModule</module-name>
   <module-name>MyOtherModule</module-name>

--- a/jakartaee9/test/app-client-resources.xml
+++ b/jakartaee9/test/app-client-resources.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client.xml
+++ b/jakartaee9/test/app-client.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<application-client xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/application-client_9.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <description xml:lang="tr">Umit</description>

--- a/jakartaee9/test/application-initialize-in-order.xml
+++ b/jakartaee9/test/application-initialize-in-order.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<application xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-       http://xmlns.eclipse.org/xml/ns/jakartaee/application_9.xsd"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+       ../build/application_9.xsd"
      version="9">
   <application-name>OrderApp</application-name>
   <description>Application description</description>

--- a/jakartaee9/test/application-libdir.xml
+++ b/jakartaee9/test/application-libdir.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<application xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-       http://xmlns.eclipse.org/xml/ns/jakartaee/application_9.xsd"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+       ../build/application_9.xsd"
      version="9">
 
   <description>Application description</description>

--- a/jakartaee9/test/application-resources.xml
+++ b/jakartaee9/test/application-resources.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<application xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-       http://xmlns.eclipse.org/xml/ns/jakartaee/application_9.xsd"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+       ../build/application_9.xsd"
      version="9">
   <application-name>OrderApp</application-name>
   <description>Application description</description>

--- a/jakartaee9/test/application.xml
+++ b/jakartaee9/test/application.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<application xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-       http://xmlns.eclipse.org/xml/ns/jakartaee/application_9.xsd"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+       ../build/application_9.xsd"
      version="9">
   <application-name>OrderApp</application-name>
   <description>Application description</description>

--- a/jakartaee9/test/connector-complete.xml
+++ b/jakartaee9/test/connector-complete.xml
@@ -18,10 +18,10 @@
 -->
 
 <!-- A Full descriptor using all the elements defined in the schema -->
-<connector xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-           http://xmlns.eclipse.org/xml/ns/jakartaee/connector_1_7.xsd"
+           xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+           ../build/connector_1_7.xsd"
            version="1.7" metadata-complete="true">
     <module-name>SimpleResourceAdapter</module-name>
     <display-name>Simple Resource Adapter</display-name>

--- a/jakartaee9/test/connector-sparse.xml
+++ b/jakartaee9/test/connector-sparse.xml
@@ -18,10 +18,10 @@
 -->
 
 <!-- A sample sparse connector DD that should validate successfully -->
-<connector xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-           http://xmlns.eclipse.org/xml/ns/jakartaee/connector_1_7.xsd"
+           xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+           ../build/connector_1_7.xsd"
            version="1.7" metadata-complete="false">
 <!-- Assuming everything else is specified via annotations (the resourceadapter-class through @Connector
 Connection Definitions through @ConnectionDefinition, message adapter configuration through @Activation

--- a/jakartaee9/test/connector.xml
+++ b/jakartaee9/test/connector.xml
@@ -18,10 +18,10 @@
 -->
 
 <!-- Identity and constraint related checks -->
-<connector xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-           http://xmlns.eclipse.org/xml/ns/jakartaee/connector_1_7.xsd"
+           xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+           ../build/connector_1_7.xsd"
            version="1.7" metadata-complete="true">
 
     <display-name>Simple Resource Adapter</display-name>

--- a/jakartaee9/test/ejb-jar-complete.xml
+++ b/jakartaee9/test/ejb-jar-complete.xml
@@ -17,12 +17,12 @@
 
 -->
 
-<ejb-jar xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-         http://xmlns.eclipse.org/xml/ns/jakartaee/ejb-jar_3_2.xsd"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         ../build/ejb-jar_4_0.xsd"
   metadata-complete="true"
-  version="3.2">
+  version="4.0">
   <display-name>Ejb1</display-name>
   <enterprise-beans>
     <session>
@@ -152,4 +152,4 @@
     </container-transaction>
   </assembly-descriptor>
 </ejb-jar>
-<?validateAgainst ejb-jar_3_2.xsd?>
+<?validateAgainst ejb-jar_4_0.xsd?>

--- a/jakartaee9/test/ejb-jar-persistence-no-lookup-name.xml
+++ b/jakartaee9/test/ejb-jar-persistence-no-lookup-name.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<ejb-jar xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-         http://xmlns.eclipse.org/xml/ns/jakartaee/ejb-jar_3_2.xsd"
-  version="3.2">
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         ../build/ejb-jar_4_0.xsd"
+  version="4.0">
   <display-name>Ejb1</display-name>
   <enterprise-beans>
     <session>
@@ -183,7 +183,7 @@
     </session>
   </enterprise-beans>
 </ejb-jar>
-<?validateAgainst ejb-jar_3_2.xsd?>
+<?validateAgainst ejb-jar_4_0.xsd?>
 <?expectError 43:cvc-identity-constraint.4.1?>
 <?expectError 99:cvc-identity-constraint.4.2.2?>
 <?expectError 118:cvc-identity-constraint.4.1?>

--- a/jakartaee9/test/ejb-jar.xml
+++ b/jakartaee9/test/ejb-jar.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<ejb-jar xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee
-         http://xmlns.eclipse.org/xml/ns/jakartaee/ejb-jar_3_2.xsd"
-  version="3.2">
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         ../build/ejb-jar_4_0.xsd"
+  version="4.0">
   <display-name>Ejb1</display-name>
   <enterprise-beans>
     <session>
@@ -3076,7 +3076,7 @@
     </container-transaction>
   </assembly-descriptor>
 </ejb-jar>
-<?validateAgainst ejb-jar_3_2.xsd?>
+<?validateAgainst ejb-jar_4_0.xsd?>
 <?expectError 43:cvc-identity-constraint.4.1?>
 <?expectError 99:cvc-identity-constraint.4.2.2?>
 <?expectError 118:cvc-identity-constraint.4.1?>

--- a/jakartaee9/test/permissions-empty.xml
+++ b/jakartaee9/test/permissions-empty.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<permissions xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/permissions_7.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/permissions_7.xsd"
     version="7">
 
 

--- a/jakartaee9/test/permissions.xml
+++ b/jakartaee9/test/permissions.xml
@@ -17,11 +17,11 @@
 
 -->
 
-<permissions xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-      http://xmlns.eclipse.org/xml/ns/jakartaee/permissions_7.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      ../build/permissions_7.xsd"
     version="7">
 
   <permission>

--- a/jakartaee9/test/web-app-complete.xml
+++ b/jakartaee9/test/web-app-complete.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<web-app xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://foobar.com"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
  metadata-complete="true"
  version="4.0">
   <default-context-path>/myappcomplete</default-context-path>

--- a/jakartaee9/test/web-app-data-source.xml
+++ b/jakartaee9/test/web-app-data-source.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<web-app xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://foobar.com"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
  version="4.0">
   <servlet>
     <servlet-name>MyInventoryServlet</servlet-name>

--- a/jakartaee9/test/web-app-resources.xml
+++ b/jakartaee9/test/web-app-resources.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<web-app xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://foobar.com"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
  version="4.0">
   <servlet>
     <servlet-name>MyInventoryServlet</servlet-name>

--- a/jakartaee9/test/web-app.xml
+++ b/jakartaee9/test/web-app.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<web-app xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://foobar.com"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-app_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
  version="4.0">
   <default-context-path>/myapp</default-context-path>
   <request-character-encoding>UTF-8</request-character-encoding>

--- a/jakartaee9/test/web-facelettaglibrary-composite.xml
+++ b/jakartaee9/test/web-facelettaglibrary-composite.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<facelet-taglib xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://mojarra.dev.java.net/mojarra_ext"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
  version="2.3"
 >
     <namespace>http://domain.com/path</namespace>

--- a/jakartaee9/test/web-facelettaglibrary-library-class.xml
+++ b/jakartaee9/test/web-facelettaglibrary-library-class.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<facelet-taglib xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://mojarra.dev.java.net/mojarra_ext"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
  version="2.3"
 >
     <library-class>com.foo.MyLibrary</library-class>

--- a/jakartaee9/test/web-facelettaglibrary-pathological-0.xml
+++ b/jakartaee9/test/web-facelettaglibrary-pathological-0.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<facelet-taglib xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://mojarra.dev.java.net/mojarra_ext"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
  version="2.3"
 >
     <library-class>com.foo.MyLibrary</library-class>

--- a/jakartaee9/test/web-facelettaglibrary-pathological-1.xml
+++ b/jakartaee9/test/web-facelettaglibrary-pathological-1.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<facelet-taglib xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://mojarra.dev.java.net/mojarra_ext"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
  version="2.3"
 >
     <namespace>http://mojarra.dev.java.net/mojarra_ext</namespace>

--- a/jakartaee9/test/web-facelettaglibrary-standard.xml
+++ b/jakartaee9/test/web-facelettaglibrary-standard.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<facelet-taglib xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://mojarra.dev.java.net/mojarra_ext"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-facelettaglibrary_2_3.xsd http://mojarra.dev.java.net/mojarra_ext http://mojarra.dev.java.net/mojarra_ext/mojarra_ext.xsd"
  version="2.3"
 >
     <namespace>http://mojarra.dev.java.net/mojarra_ext</namespace>

--- a/jakartaee9/test/web-facesconfig-pathological-0.xml
+++ b/jakartaee9/test/web-facesconfig-pathological-0.xml
@@ -17,9 +17,9 @@
 
 -->
 
-<faces-config xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee http://xmlns.eclipse.org/xml/ns/jakartaee/web-facesconfig_2_3.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee ../build/web-facesconfig_2_3.xsd"
     version="2.3">
 
 

--- a/jakartaee9/test/web-facesconfig-standard.xml
+++ b/jakartaee9/test/web-facesconfig-standard.xml
@@ -17,9 +17,9 @@
 
 -->
 
-<faces-config xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee http://xmlns.eclipse.org/xml/ns/jakartaee/web-facesconfig_2_3.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee ../build/web-facesconfig_2_3.xsd"
     version="2.3">
 
   <application>

--- a/jakartaee9/test/web-fragment-complete.xml
+++ b/jakartaee9/test/web-fragment-complete.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<web-fragment xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<web-fragment xmlns="https://jakarta.ee/xml/ns/jakartaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
  xmlns:foobar="http://foobar.com"
- xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee web-fragment_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-fragment_4_0.xsd http://foobar.com http://foobar.com/foobar.xsd"
  metadata-complete="true"
  version="4.0">
   <name>A</name>

--- a/jakartaee9/test/web-partialresponse-standard.xml
+++ b/jakartaee9/test/web-partialresponse-standard.xml
@@ -17,9 +17,9 @@
 
 -->
 
-<partial-response xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<partial-response xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee http://xmlns.eclipse.org/xml/ns/jakartaee/web-partialresponse_2_3.xsd" id="partial">
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee ../build/web-partialresponse_2_3.xsd" id="partial">
 
   <changes>
     <update id="1">

--- a/jakartaee9/test/web-service-features.xml
+++ b/jakartaee9/test/web-service-features.xml
@@ -17,10 +17,10 @@
 
 -->
 
-<webservices xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<webservices xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-               http://xmlns.eclipse.org/xml/ns/jakartaee/jakartaee_web_services_1_4.xsd"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+               ../build/jakartaee_web_services_1_4.xsd"
              version="1.4">
   <webservice-description>
     <webservice-description-name>JoesServices</webservice-description-name>

--- a/jakartaee9/test/web-service-handler.xml
+++ b/jakartaee9/test/web-service-handler.xml
@@ -17,13 +17,13 @@
 
 -->
 
-<webservices xmlns="http://xmlns.eclipse.org/xml/ns/jakartaee"
+<webservices xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:wsdl="http://Hello.org"
              xmlns:soap1="http://HandlerInfo.org/Server1"
              xmlns:soap2="http://HandlerInfo.org/Server2"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://xmlns.eclipse.org/xml/ns/jakartaee 
-               http://xmlns.eclipse.org/xml/ns/jakartaee/jakartaee_web_services_1_4.xsd"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+               ../build/jakartaee_web_services_1_4.xsd"
              version="1.4">
   <webservice-description>
     <webservice-description-name>HandlerInfoTest</webservice-description-name>


### PR DESCRIPTION
* Changed http://xmlns.eclipse.org/xml/ns/jakartaee to https://jakarta.ee/xml/ns/jakartaee in all files
* Changed Java EE to Jakarta EE
* Renamed ejb-jar_3_2.xsds to ejb-jar_4_0.xsds
* Changed version from 3.2 to 4.0 in ejb-jar_4_0.xsds
* Changed EJB to Enterprise Beans in content and comments
* Updated tests to validateAgainst ejb-jar_4_0.xsd
* Changed all tests to resolve schema location in build directory
  since https://jakarta.ee/xml/ns/jakartaee does not exist

Signed-off-by: hussainm <hussain.nm@cognizant.com>