### PR TITLE
Fix test errors and update copyright year in test xmls

### DIFF
--- a/jakartaee9/src/web-common_4_0.xsds
+++ b/jakartaee9/src/web-common_4_0.xsds
@@ -73,7 +73,7 @@
 <!-- **************************************************** -->
 
   <xsd:include schemaLocation="jakartaee_9.xsd"/>
-  <xsd:include schemaLocation="jsp_2_3.xsd"/>
+  <xsd:include schemaLocation="jsp_3_0.xsd"/>
 
 <!-- **************************************************** -->
 

--- a/jakartaee9/test/app-client-complete.xml
+++ b/jakartaee9/test/app-client-complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     metadata-complete="true"
     version="9">
   <module-name>MyModule</module-name>

--- a/jakartaee9/test/app-client-data-source.xml
+++ b/jakartaee9/test/app-client-data-source.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client-handler.xml
+++ b/jakartaee9/test/app-client-handler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     version="9">
   <display-name>HandlerInfoTestClnt_client</display-name>
   <service-ref>

--- a/jakartaee9/test/app-client-injection.xml
+++ b/jakartaee9/test/app-client-injection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client-mapped-name.xml
+++ b/jakartaee9/test/app-client-mapped-name.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client-module.xml
+++ b/jakartaee9/test/app-client-module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     version="9">
   <module-name>MyModule</module-name>
   <module-name>MyOtherModule</module-name>

--- a/jakartaee9/test/app-client-resources.xml
+++ b/jakartaee9/test/app-client-resources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <display-name>MyAppClient</display-name>

--- a/jakartaee9/test/app-client.xml
+++ b/jakartaee9/test/app-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/application-client_9.xsd"
+      application-client_9.xsd"
     version="9">
   <description xml:lang="en">This is my app client</description>
   <description xml:lang="tr">Umit</description>

--- a/jakartaee9/test/application-initialize-in-order.xml
+++ b/jakartaee9/test/application-initialize-in-order.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-       ../build/application_9.xsd"
+       application_9.xsd"
      version="9">
   <application-name>OrderApp</application-name>
   <description>Application description</description>

--- a/jakartaee9/test/application-libdir.xml
+++ b/jakartaee9/test/application-libdir.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-       ../build/application_9.xsd"
+       application_9.xsd"
      version="9">
 
   <description>Application description</description>

--- a/jakartaee9/test/application-resources.xml
+++ b/jakartaee9/test/application-resources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-       ../build/application_9.xsd"
+       application_9.xsd"
      version="9">
   <application-name>OrderApp</application-name>
   <description>Application description</description>

--- a/jakartaee9/test/application.xml
+++ b/jakartaee9/test/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-       ../build/application_9.xsd"
+       application_9.xsd"
      version="9">
   <application-name>OrderApp</application-name>
   <description>Application description</description>

--- a/jakartaee9/test/connector-complete.xml
+++ b/jakartaee9/test/connector-complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
 <connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-           ../build/connector_1_7.xsd"
+           connector_1_7.xsd"
            version="1.7" metadata-complete="true">
     <module-name>SimpleResourceAdapter</module-name>
     <display-name>Simple Resource Adapter</display-name>

--- a/jakartaee9/test/connector-sparse.xml
+++ b/jakartaee9/test/connector-sparse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
 <connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-           ../build/connector_1_7.xsd"
+           connector_1_7.xsd"
            version="1.7" metadata-complete="false">
 <!-- Assuming everything else is specified via annotations (the resourceadapter-class through @Connector
 Connection Definitions through @ConnectionDefinition, message adapter configuration through @Activation

--- a/jakartaee9/test/connector.xml
+++ b/jakartaee9/test/connector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@
 <connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-           ../build/connector_1_7.xsd"
+           connector_1_7.xsd"
            version="1.7" metadata-complete="true">
 
     <display-name>Simple Resource Adapter</display-name>

--- a/jakartaee9/test/ejb-jar-complete.xml
+++ b/jakartaee9/test/ejb-jar-complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 <ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         ../build/ejb-jar_4_0.xsd"
+         ejb-jar_4_0.xsd"
   metadata-complete="true"
   version="4.0">
   <display-name>Ejb1</display-name>

--- a/jakartaee9/test/ejb-jar-persistence-no-lookup-name.xml
+++ b/jakartaee9/test/ejb-jar-persistence-no-lookup-name.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,8 @@
 
 <ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         ../build/ejb-jar_4_0.xsd"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+	     ejb-jar_4_0.xsd"
   version="4.0">
   <display-name>Ejb1</display-name>
   <enterprise-beans>

--- a/jakartaee9/test/ejb-jar.xml
+++ b/jakartaee9/test/ejb-jar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,9 +19,9 @@
 
 <ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         ../build/ejb-jar_4_0.xsd"
-  version="4.0">
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+	     ejb-jar_4_0.xsd"
+	 version="4.0">
   <display-name>Ejb1</display-name>
   <enterprise-beans>
     <session>

--- a/jakartaee9/test/permissions-empty.xml
+++ b/jakartaee9/test/permissions-empty.xml
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/permissions_7.xsd"
+      permissions_7.xsd"
     version="7">
 
 

--- a/jakartaee9/test/permissions.xml
+++ b/jakartaee9/test/permissions.xml
@@ -21,7 +21,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns:xml="http://www.w3.org/XML/1998/namespace" 
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-      ../build/permissions_7.xsd"
+      permissions_7.xsd"
     version="7">
 
   <permission>

--- a/jakartaee9/test/web-app-complete.xml
+++ b/jakartaee9/test/web-app-complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-app-data-source.xml
+++ b/jakartaee9/test/web-app-data-source.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-app-resources.xml
+++ b/jakartaee9/test/web-app-resources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-app.xml
+++ b/jakartaee9/test/web-app.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-facelettaglibrary-composite.xml
+++ b/jakartaee9/test/web-facelettaglibrary-composite.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-facelettaglibrary-library-class.xml
+++ b/jakartaee9/test/web-facelettaglibrary-library-class.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-facelettaglibrary-pathological-0.xml
+++ b/jakartaee9/test/web-facelettaglibrary-pathological-0.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-facelettaglibrary-pathological-1.xml
+++ b/jakartaee9/test/web-facelettaglibrary-pathological-1.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-facelettaglibrary-standard.xml
+++ b/jakartaee9/test/web-facelettaglibrary-standard.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-facesconfig-pathological-0.xml
+++ b/jakartaee9/test/web-facesconfig-pathological-0.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
 
 <faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee ../build/web-facesconfig_2_3.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-facesconfig_2_3.xsd"
     version="2.3">
 
 

--- a/jakartaee9/test/web-facesconfig-standard.xml
+++ b/jakartaee9/test/web-facesconfig-standard.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
 
 <faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee ../build/web-facesconfig_2_3.xsd"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-facesconfig_2_3.xsd"
     version="2.3">
 
   <application>

--- a/jakartaee9/test/web-fragment-complete.xml
+++ b/jakartaee9/test/web-fragment-complete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jakartaee9/test/web-partialresponse-standard.xml
+++ b/jakartaee9/test/web-partialresponse-standard.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
 
 <partial-response xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee ../build/web-partialresponse_2_3.xsd" id="partial">
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-partialresponse_2_3.xsd" id="partial">
 
   <changes>
     <update id="1">

--- a/jakartaee9/test/web-service-features.xml
+++ b/jakartaee9/test/web-service-features.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 <webservices xmlns="https://jakarta.ee/xml/ns/jakartaee"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-               ../build/jakartaee_web_services_1_4.xsd"
+               jakartaee_web_services_1_4.xsd"
              version="1.4">
   <webservice-description>
     <webservice-description-name>JoesServices</webservice-description-name>

--- a/jakartaee9/test/web-service-handler.xml
+++ b/jakartaee9/test/web-service-handler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@
              xmlns:soap2="http://HandlerInfo.org/Server2"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
-               ../build/jakartaee_web_services_1_4.xsd"
+               jakartaee_web_services_1_4.xsd"
              version="1.4">
   <webservice-description>
     <webservice-description-name>HandlerInfoTest</webservice-description-name>


### PR DESCRIPTION
 
- Fix test errors in web-app.xml due to jsp_3_0.xsd

````
sax error: 118:src-resolve: Cannot resolve the name 'jakartaee:jsp-configType' to a(n) 'type definition' component.
sax error: 721:src-resolve: Cannot resolve the name 'jakartaee:jsp-fileType' to a(n) 'type definition' component.
````

- Update copyright year to 2020 in test xmls
- Remove relative path in schemaLocation
