### PR TITLE
alignment with Concurrency 141

### DIFF
--- a/xml/src/application_10.xsds
+++ b/xml/src/application_10.xsds
@@ -230,7 +230,19 @@
                    minOccurs="0" maxOccurs="unbounded"/> 
       <xsd:element name="administered-object" 
                    type="jakartaee:administered-objectType" 
-                   minOccurs="0" maxOccurs="unbounded"/> 
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="context-service"
+                   type="jakartaee:context-serviceType"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-executor"
+                   type="jakartaee:managed-executorType"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-scheduled-executor"
+                   type="jakartaee:managed-scheduled-executorType"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-thread-factory"
+                   type="jakartaee:managed-thread-factoryType"
+                   minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="version"
 		   type="jakartaee:dewey-versionType"

--- a/xml/src/jakartaee_10.xsds
+++ b/xml/src/jakartaee_10.xsds
@@ -134,6 +134,18 @@
       <xsd:element name="administered-object" 
                    type="jakartaee:administered-objectType" 
                    minOccurs="0" maxOccurs="unbounded"/> 
+      <xsd:element name="context-service"
+                   type="jakartaee:context-serviceType"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-executor"
+                   type="jakartaee:managed-executorType"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-scheduled-executor"
+                   type="jakartaee:managed-scheduled-executorType"
+                   minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="managed-thread-factory"
+                   type="jakartaee:managed-thread-factoryType"
+                   minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
   </xsd:group>
 
@@ -405,6 +417,128 @@
     </xsd:sequence>
     <xsd:attribute name="id"
                    type="xsd:ID"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="context-serviceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ContextService.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ContextService.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ContextService instance being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="cleared"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Types of context to clear whenever a thread runs a
+            contextual task or action. The thread's previous context
+            is restored afterward. Context types that are defined by
+            the Jakarta EE Concurrency specification include:
+            Application, Security, Transaction,
+            and Remaining, which means all available thread context
+            types that are not specified elsewhere. You can also specify
+            vendor-specific context types. Absent other configuration,
+            cleared context defaults to Transaction. You can specify
+            a single cleared element with no value to indicate an
+            empty list of context types to clear. If neither
+            propagated nor unchanged specify (or default to) Remaining,
+            then Remaining is automatically appended to the list of
+            cleared context types.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="propagated"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Types of context to capture from the requesting thread
+            and propagate to a thread that runs a contextual task
+            or action. The captured context is re-established
+            when threads run the contextual task or action,
+            with the respective thread's previous context being
+            restored afterward. Context types that are defined by
+            the Jakarta EE Concurrency specification include:
+            Application, Security,
+            and Remaining, which means all available thread context
+            types that are not specified elsewhere. You can also specify
+            vendor-specific context types. Absent other configuration,
+            propagated context defaults to Remaining. You can specify
+            a single propagated element with no value to indicate that
+            no context types should be propagated.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="unchanged"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Types of context that are left alone when a thread runs a
+            contextual task or action. Context types that are defined
+            by the Jakarta EE Concurrency specification include:
+            Application, Security, Transaction,
+            and Remaining, which means all available thread context
+            types that are not specified elsewhere. You can also specify
+            vendor-specific context types. Absent other configuration,
+            unchanged context defaults to empty. You can specify
+            a single unchanged element with no value to indicate that
+            no context types should be left unchanged.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
   </xsd:complexType>
 
   <!-- **************************************************** -->
@@ -1847,6 +1981,293 @@
 
   <!-- ***************************************************** -->
 
+  <xsd:complexType name="managed-executorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ManagedExecutorService.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ManagedExecutorService.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ManagedExecutorService instance being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-service-ref"
+                   type="jakartaee:jndi-nameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Refers to the name of a ContextServiceDefinition or
+            context-service deployment descriptor element,
+            which determines how context is applied to tasks and actions
+            that run on this executor.
+            The name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            In the absence of a configured value,
+            java:comp/DefaultContextService is used.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-async"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Upper bound on contextual tasks and actions that this executor
+            will simultaneously execute asynchronously. This constraint does
+            not apply to tasks and actions that the executor runs inline,
+            such as when a thread requests CompletableFuture.join and the
+            action runs inline if it has not yet started.
+            The default is unbounded, although still subject to
+            resource constraints of the system.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="hung-task-threshold"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The amount of time in milliseconds that a task or action
+            can execute before it is considered hung.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="managed-scheduled-executorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ManagedScheduledExecutorService.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ManagedScheduledExecutorService.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ManagedScheduledExecutorService instance
+            being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-service-ref"
+                   type="jakartaee:jndi-nameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Refers to the name of a ContextServiceDefinition or
+            context-service deployment descriptor element,
+            which determines how context is applied to tasks and actions
+            that run on this executor.
+            The name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            In the absence of a configured value,
+            java:comp/DefaultContextService is used.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-async"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Upper bound on contextual tasks and actions that this executor
+            will simultaneously execute asynchronously. This constraint does
+            not apply to tasks and actions that the executor runs inline,
+            such as when a thread requests CompletableFuture.join and the
+            action runs inline if it has not yet started. This constraint also
+            does not apply to tasks that are scheduled via the schedule methods.
+            The default is unbounded, although still subject to
+            resource constraints of the system.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="hung-task-threshold"
+                   type="jakartaee:xsdPositiveIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The amount of time in milliseconds that a task or action
+            can execute before it is considered hung.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="managed-thread-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a ManagedThreadFactory.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this ManagedThreadFactory.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JNDI name of the ManagedThreadFactory instance being defined.
+            The JNDI name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-service-ref"
+                   type="jakartaee:jndi-nameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Refers to the name of a ContextServiceDefinition or
+            context-service deployment descriptor element,
+            which determines how context is applied to threads
+            from this thread factory.
+            The name must be in a valid Jakarta EE namespace,
+            such as java:comp, java:module, java:app, or java:global.
+            In the absence of a configured value,
+            java:comp/DefaultContextService is used.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="priority"
+                   type="jakartaee:priorityType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Priority for threads created by this thread factory.
+            The default is 5 (java.lang.Thread.NORM_PRIORITY).
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Vendor-specific property.
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
+
   <xsd:complexType name="param-valueType">
     <xsd:annotation>
       <xsd:documentation>
@@ -2082,7 +2503,25 @@
     </xsd:simpleContent>
   </xsd:complexType>
 
-<!-- **************************************************** -->
+  <!-- **************************************************** -->
+
+  <xsd:complexType name="priorityType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies a thread priority value in the range of
+        1 (java.lang.Thread.MIN_PRIORITY) to 10 (java.lang.Thread.MAX_PRIORITY).
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdPositiveIntegerType">
+        <xsd:maxInclusive value="10"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <!-- **************************************************** -->
 
   <xsd:complexType name="propertyType">
     <xsd:annotation>

--- a/xml/test/application-concurrency.xml
+++ b/xml/test/application-concurrency.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee application_10.xsd"
+ version="10">
+
+  <module>
+    <web>
+      <web-uri>my-web.war</web-uri>
+      <context-root>/start</context-root>
+    </web>
+  </module>
+
+  <context-service>
+    <name>java:app/concurrent/SecContextOnly</name>
+    <cleared></cleared>
+    <propagated>Security</propagated>
+    <unchanged>Remaining</unchanged>
+  </context-service>
+
+  <managed-executor>
+    <name>java:app/concurrent/Executor20</name>
+    <context-service-ref>java:app/concurrent/SecContextOnly</context-service-ref>
+    <max-async>20</max-async>
+  </managed-executor>
+
+  <managed-scheduled-executor>
+    <name>java:app/concurrent/sched-exec-1</name>
+    <context-service-ref>java:app/concurrent/SecContextOnly</context-service-ref>
+  </managed-scheduled-executor>
+
+  <managed-scheduled-executor>
+    <name>java:global/concurrent/sched-exec-2</name>
+    <max-async>2</max-async>
+  </managed-scheduled-executor>
+
+  <managed-thread-factory>
+    <name>java:global/concurrent/top-priority-threads</name>
+    <priority>10</priority>
+  </managed-thread-factory>
+
+</application>
+<?validateAgainst application_10.xsd?>

--- a/xml/test/ejb-jar-concurrency.xml
+++ b/xml/test/ejb-jar-concurrency.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee ejb-jar_4_0.xsd"
+	 version="4.0">
+
+  <enterprise-beans>
+    <session>
+      <ejb-name>MySessionBean</ejb-name>
+      <ejb-class>jakarta.schema.example.ejb.MySessionBean</ejb-class>
+      <context-service>
+        <name>java:app/concurrent/AppContext</name>
+        <cleared>Security</cleared>
+        <cleared>Transaction</cleared>
+        <propagated>Application</propagated>
+        <unchanged>Remaining</unchanged>
+      </context-service>
+      <managed-thread-factory>
+        <name>java:module/concurrent/lowest-priority-threads</name>
+        <priority>1</priority>
+      </managed-thread-factory>
+    </session>
+    <entity>
+      <ejb-name>MyEntityBean</ejb-name>
+      <ejb-class>jakarta.schema.example.ejb.MyEntityBean</ejb-class>
+      <persistence-type>Bean</persistence-type>
+      <prim-key-class>java.lang.String</prim-key-class>
+      <reentrant>false</reentrant>
+      <managed-executor>
+        <name>java:app/concurrent/executor-1</name>
+        <context-service-ref>java:app/concurrent/AppContext</context-service-ref>
+      </managed-executor>
+      <managed-executor>
+        <name>java:module/concurrent/executor-2</name>
+        <max-async>2</max-async>
+      </managed-executor>
+      <managed-scheduled-executor>
+        <name>java:comp/concurrent/my-scheduled-executor</name>
+        <max-async>10</max-async>
+        <hung-task-threshold>50000</hung-task-threshold>
+      </managed-scheduled-executor>
+    </entity>
+    <message-driven>
+      <ejb-name>MyMessageDrivenBean</ejb-name>
+      <ejb-class>jakarta.schema.example.ejb.MyMessageDrivenBean</ejb-class>
+      <managed-scheduled-executor>
+        <name>java:comp/concurrent/my-scheduled-executor</name>
+        <max-async>5</max-async>
+      </managed-scheduled-executor>
+    </message-driven>
+  </enterprise-beans>
+
+</ejb-jar>
+<?validateAgainst ejb-jar_4_0.xsd?>

--- a/xml/test/web-app-concurrency.xml
+++ b/xml/test/web-app-concurrency.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee web-app_6_0.xsd"
+ version="6.0">
+  <servlet>
+    <servlet-name>MyServlet</servlet-name>
+    <servlet-class>jakarta.schema.example.web.MyServlet</servlet-class>
+    <load-on-startup></load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>MyServlet</servlet-name>
+    <url-pattern>/example/my-servlet</url-pattern>
+  </servlet-mapping>
+
+  <context-service>
+    <description>An example ContextService definition.</description>
+    <name>java:app/concurrent/MyContext</name>
+    <cleared>Remaining</cleared>
+    <propagated>Security</propagated>
+    <propagated>Application</propagated>
+    <propagated>VendorContext1</propagated>
+    <unchanged>VendorContext2</unchanged>
+    <unchanged>Transaction</unchanged>
+    <property>
+      <name>VendorProp1</name>
+      <value>Yes</value>
+    </property>
+    <property>
+      <name>VendorProp2</name>
+      <value>10</value>
+    </property>
+  </context-service>
+
+  <context-service>
+    <name>java:global/concurrent/MinimalContext</name>
+    <propagated></propagated>
+    <unchanged>Remaining</unchanged>
+  </context-service>
+
+  <managed-executor>
+    <description>An example ManagedExecutorService definition.</description>
+    <name>java:module/concurrent/MyExecutor</name>
+    <context-service-ref>java:app/concurrent/MyContext</context-service-ref>
+    <hung-task-threshold>30000</hung-task-threshold>
+    <property>
+      <name>HungTaskAction</name>
+      <value>Panic</value>
+    </property>
+  </managed-executor>
+
+  <managed-executor>
+    <name>java:comp/concurrent/SingleThreadedExecutor</name>
+    <max-async>1</max-async>
+  </managed-executor>
+
+  <managed-scheduled-executor>
+    <description>An example ManagedScheduledExecutorService definition.</description>
+    <name>java:comp/concurrent/MyScheduledExecutor</name>
+    <context-service-ref>java:global/concurrent/MinimalContext</context-service-ref>
+    <max-async>10</max-async>
+    <property>
+      <name>isSkippingEnabled</name>
+      <value>false</value>
+    </property>
+  </managed-scheduled-executor>
+
+  <managed-thread-factory>
+    <description>An example ManagedThreadFactory definition.</description>
+    <name>java:app/concurrent/MyThreadFactory</name>
+    <context-service-ref>java:app/concurrent/MyContext</context-service-ref>
+    <priority>4</priority>
+    <property>
+      <name>thread-name-prefix</name>
+      <value>MyThread!</value>
+    </property>
+  </managed-thread-factory>
+
+</web-app>
+<?validateAgainst web-app_6_0.xsd ?>


### PR DESCRIPTION
fixes #28

This pulls aligns the deployment descriptors with the annotations from https://github.com/eclipse-ee4j/concurrency-api/pull/141

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>