### PR TITLE
Revert connector 2.0 import of jakartaee_10.xsd to jakartaee_9.xsd.

### DIFF
--- a/xml/src/connector_2_0.xsds
+++ b/xml/src/connector_2_0.xsds
@@ -72,7 +72,7 @@
 
   <!-- **************************************************** -->
 
-  <xsd:include schemaLocation="jakartaee_10.xsd"/>
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
 
 
 <!-- **************************************************** -->


### PR DESCRIPTION
Partial update for issue #32.  This pull request reverts the update which was made to the connector 2.0 schema.